### PR TITLE
Get-Tools.ps1 TLS1.2 fix

### DIFF
--- a/DjvuNet.Build/Get-Tools.ps1
+++ b/DjvuNet.Build/Get-Tools.ps1
@@ -12,6 +12,8 @@ param(
 $retryCount = 0
 $success = $false
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 do {
     try {
         Write-Output "Downloading $ToolsName from $ToolsRemotePath"


### PR DESCRIPTION
Due to Github migration from TLS1.0 to TLS1.2 - powershell downloading script doesn't work anymore